### PR TITLE
Merge changes from upstream to fix "rm: cannot remove '/app': Read-only file system"

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # bin/compile <build-dir> <cache-dir> <env-dir>
 
+# Ensure wildcards in globs match dotfiles too.
+shopt -s dotglob
+
 BUILD_DIR=${1:-}
 CACHE_DIR=${2:-}
 ENV_DIR=${3:-}
@@ -16,9 +19,7 @@ if [ -f $ENV_DIR/PROJECT_PATH ]; then
 		echo "       moving working dir: $PROJECT_PATH to $TMP_DIR"
 		cp -R $BUILD_DIR/$PROJECT_PATH/. $TMP_DIR/
 	 	echo "       cleaning build dir $BUILD_DIR"
-		rm -rf $BUILD_DIR
-		echo "       recreating $BUILD_DIR"
-		mkdir -p $BUILD_DIR
+		rm -rf $BUILD_DIR/*
 		echo "       copying preserved work dir from cache $TMP_DIR to build dir $BUILD_DIR"
 		cp -R $TMP_DIR/. $BUILD_DIR/
 		echo "       cleaning tmp dir $TMP_DIR"


### PR DESCRIPTION
Hi

I'm on the team that maintains Heroku's build system and official buildpacks.

Very soon we are going to make a change to the Heroku build system that will mean builds using this buildpack emit warnings like:

```
remote: -----> Subdir buildpack app detected
remote: -----> Subdir buildpack in <DIRECTORY>
remote:        creating cache: /tmp/codon/tmp/cache
remote:        created tmp dir: /tmp/codon/tmp/cache/subdirXF9Kh
remote:        moving working dir: <DIRECTORY> to /tmp/codon/tmp/cache/subdirXF9Kh
remote:        cleaning build dir /app
remote: rm: cannot remove '/app': Read-only file system
```

A fix for these build log warnings has been merged into the upstream repository from which this one is forked:
https://github.com/timanovsky/subdir-heroku-buildpack/pull/10

This PR merges the changes from the upstream repository (which include that fix) back to this fork, so as to avoid these warnings in your builds in the future.

If you would like to avoid the merge commit from this PR (so that the two repository's Git histories do not diverge), then I'd recommend closing this PR as unmerged, and instead pulling upstream directly into `master` of this repo.

For more information about the upcoming Heroku build system change and why this fix was needed, see:
https://github.com/timanovsky/subdir-heroku-buildpack/issues/9

I'm also happy to answer any questions you may have via discussion on this PR :-)

cc @XGDragon